### PR TITLE
Revert "Disable Station Destruction Artifact Effect (#1441)"

### DIFF
--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -666,7 +666,7 @@
   - type: SpawnArtifact
     maxSpawns: 1
     spawns:
-    - id: SingularityToy # DeltaV - no singuloose
+    - id: Singularity
 
 - type: artifactEffect
   id: EffectTesla
@@ -676,4 +676,4 @@
   - type: SpawnArtifact
     maxSpawns: 1
     spawns:
-    - id: TeslaToy # DeltaV - no teslaloose
+    - id: TeslaEnergyBall


### PR DESCRIPTION
## About the PR
Everyone gets to singuloose at least once. As a treat. This reverts commit 82e28e4ecee2a656561057aca096c5512d7625d7.

## Why / Balance
Why the fuck did delta remove this, engineering singulooses like every 3 fucking shifts how is once a week tesloose a major issue what

## Requirements
Can we get rid of this fucking thing and change it for the much better EE format? Thanks

- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: Mocho
- add: Readded station wide destruction.
